### PR TITLE
Fixing issue with zoom

### DIFF
--- a/RelativeLineNumbers.cs
+++ b/RelativeLineNumbers.cs
@@ -65,15 +65,32 @@ namespace RelativeLineNumbers
 			_fontFamily = _textView.FormattedLineSource.DefaultTextProperties.Typeface.FontFamily;
 			_fontEmSize = _textView.FormattedLineSource.DefaultTextProperties.FontRenderingEmSize;
 
-			this.Width = GetMarginWidth(new Typeface(_fontFamily.Source), _fontEmSize) + 2 * _labelOffsetX;
+            SetMarginWidth();
+
 			_textView.Caret.PositionChanged += new EventHandler<CaretPositionChangedEventArgs>(OnCaretPositionChanged);
 			_textView.ViewportHeightChanged += (sender, args) => DrawLineNumbers();
 			_textView.LayoutChanged += new EventHandler<TextViewLayoutChangedEventArgs>(OnLayoutChanged);
+            _textView.ZoomLevelChanged += (sender, args) => SetMarginWidth();
 			_formatMap.FormatMappingChanged += (sender, args) => DrawLineNumbers();
 
 			this.ToolTip = "To customize Relative Line Numbers select:\n" +
 			               "  Tools -> Options -> Fonts and Colors -> Relative Line Numbers";
 		}
+
+        private double FontSize
+        {
+            get { return _fontEmSize * ZoomFactor; }
+        }
+
+        private void SetMarginWidth()
+        {
+            this.Width = GetMarginWidth(new Typeface(_fontFamily.Source), FontSize) + 2 * _labelOffsetX;
+        }
+
+        private double ZoomFactor
+        {
+            get { return _textView.ZoomLevel / 100d; }
+        }
 
 		#endregion
 
@@ -124,11 +141,11 @@ namespace RelativeLineNumbers
 				TextBlock tb = new TextBlock();
 				tb.Text = string.Format("{0,2}", Math.Abs(cursorLineIndex - i));
 				tb.FontFamily = _fontFamily;
-				tb.FontSize = _fontEmSize;
+                tb.FontSize = FontSize; 
 				tb.Foreground = fgBrush;
 				tb.FontWeight = fontWeight;
 				Canvas.SetLeft(tb, _labelOffsetX);
-				Canvas.SetTop(tb, _textView.TextViewLines[i].TextTop - _textView.ViewportTop);
+				Canvas.SetTop(tb, (_textView.TextViewLines[i].TextTop - _textView.ViewportTop) * ZoomFactor);
 				_canvas.Children.Add(tb);
 			}
 		}
@@ -144,7 +161,7 @@ namespace RelativeLineNumbers
 			System.Globalization.CultureInfo.GetCultureInfo("en-us"),
 			System.Windows.FlowDirection.LeftToRight,
 			fontTypeFace,
-			fontSize,
+			FontSize,
 			Brushes.Black);
 
 			return formattedText.MinWidth;


### PR DESCRIPTION
When zooming text the line numbers get all messed up.  This uses the _textView zooming factor to adjust the width, the font size, and textblock spacing.
